### PR TITLE
Updates to `import_local()` and `swmpr()`

### DIFF
--- a/R/swmpr_misc.R
+++ b/R/swmpr_misc.R
@@ -41,7 +41,7 @@ swmpr <- function(stat_in, meta_in){
     fcols <- grep('^f_', names(stat_in),value = TRUE)
     stat_in[, fcols] <- sapply(fcols, function(x){
       
-      out <- gsub('\\s+$', '', stat_in[, x])
+      out <- trimws(stat_in[, x], which = 'right') #gsub('\\s+$', '', stat_in[, x])
       return(out)
       
     })

--- a/R/swmpr_retrieval.R
+++ b/R/swmpr_retrieval.R
@@ -307,6 +307,7 @@ single_param <- function(station_code, param, Max = 100, trace = TRUE){
 #' @param  path chr string of full path to .csv files with raw data, can be a zipped or unzipped directory where the former must include the .zip extension
 #' @param  station_code chr string of station to import, typically 7 or 8 characters including wq, nut, or met extensions, may include full name with year, excluding file extension
 #' @param  trace logical indicating if progress is sent to console, default \code{FALSE}
+#' @param collMethd chr string of nutrient data to subset. 1 indicates monthly, 2 indicates diel. Default is both diel and monthly data.
 #' 
 #' @concept retrieve
 #' 
@@ -480,6 +481,16 @@ import_local <- function(path, station_code, trace = FALSE){
   
   # remove rows with no datetimestamp
   out <- out[!is.na(out$datetimestamp), ]
+  
+  # if nut, filter for relevant nutrient data
+  if(parm == 'nut'){
+    if(length(unique(out$collmethd)) == 2){
+      out <- out[out$collmethd %in% collMethd, ]
+    }else{
+      warning('This station does not have diel sampling data. All data will be retained.', call. = FALSE)
+      out <- out
+    }
+  }
   
   # convert output to data frame
   # retain only relevant columns


### PR DESCRIPTION
This pull request adds two small updates to `import_local()` and `swmpr()`.

`swmpr()`
I suggest swapping `trimws()` for `gsub()` when removing trailing white spaces from the QAQC columns. I ran into formatting issues when manually converting data into swmpr objects when the QAQC columns did not have trialing white space. Using `trimws()` corrects this issue.

`import_local()`
I added a new argument to `import_local` called `collMethd`. This argument allows the user to filter nutrient data if they want, since CDMO provides both monthly sampling data and diel sampling data together.

Please let me know if there are any issues with this pull request! This is my first time contributing to someone else's package.